### PR TITLE
Test error? method for errors from rules

### DIFF
--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -40,6 +40,35 @@ RSpec.describe Dry::Validation::Result do
     end
   end
 
+  describe '#error?' do
+
+    let(:params) do
+      double(:params, message_set: [], to_h: { email: 'jane@doe.org', blank: '' })
+    end
+
+    let(:result) do
+      Dry::Validation::Result.new(params) do |r|
+        r.add_error(Dry::Validation::Message.new('email error', path: [:email]))
+      end
+    end
+
+    it 'returns true for an error from the schema' do
+      allow(params).to receive(:error?).
+        with(:blank).
+        and_return(true)
+
+      expect(result.error?(:blank)).to be true
+    end
+
+    it 'returns true for an error added by the validation' do
+      allow(params).to receive(:error?).
+        with(:email).
+        and_return(false)
+
+      expect(result.error?(:email)).to be true
+    end
+  end
+
   describe '#inspect' do
     let(:params) do
       double(:params, message_set: [], to_h: {})


### PR DESCRIPTION
Currently it seems to only detect errors from schemas.

Example error output:

```
rspec ./spec/integration/result_spec.rb

Randomized with seed 22011
...F..

Failures:

  1) Dry::Validation::Result#error? returns true for an error added by the validation
     Failure/Error: expect(result.error?(:email)).to be true
     
       expected true
            got false
     # ./spec/integration/result_spec.rb:68:in `block (3 levels) in <top (required)>'

Finished in 0.01844 seconds (files took 0.37993 seconds to load)
6 examples, 1 failure

Failed examples:

rspec ./spec/integration/result_spec.rb:63 # Dry::Validation::Result#error? returns true for an error added by the validation

Randomized with seed 22011
```

After reading the contribution guidelines I don't think I should submit this to `dry-validation` without further discussion, so I'm opening this PR against the forked repository just to have somewhere to link to.